### PR TITLE
Fix optional numpy import and require pandas

### DIFF
--- a/QQQAstro.py
+++ b/QQQAstro.py
@@ -23,8 +23,16 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, Tuple
 
-import numpy as np  # noqa: F401 (may be useful later)
-import pandas as pd
+try:
+    import numpy as np  # noqa: F401 – optional helper
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    np = None
+
+try:
+    import pandas as pd
+except ModuleNotFoundError as exc:
+    raise SystemExit("✗ pandas is required but not installed.") from exc
+
 import pytz
 
 # ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- make numpy optional, exit if pandas missing

## Testing
- `python -m py_compile QQQAstro.py`
- `python QQQAstro.py --help` *(fails: pandas not installed)*

------
https://chatgpt.com/codex/tasks/task_b_684870daf2348321a864749bc8258bb5