### PR TITLE
Add support for QQQ_DATA_DIR

### DIFF
--- a/QQQAstro.py
+++ b/QQQAstro.py
@@ -8,10 +8,12 @@ Adds:
 
 Run:
   python qqq_pipeline_v2.py --csv /path/to/QQQ.csv --out enriched.csv
-If --csv is omitted it tries to auto‑detect a QQQ‑named CSV in /mnt/data
+If --csv is omitted it tries to auto‑detect a QQQ‑named CSV in $QQQ_DATA_DIR
+(default: ./mnt/data)
 """
 
 import math
+import os
 from pathlib import Path
 from datetime import datetime, timezone
 from typing import Dict
@@ -112,16 +114,18 @@ def enrich(csv_path: Path, out_path: Path):
 
 # ------------------------- CLI glue ---------------------------------
 def locate_default_csv() -> Path:
-    root = Path('/mnt/data')
+    env_root = os.getenv('QQQ_DATA_DIR')
+    root = Path(env_root) if env_root else Path('./mnt/data')
     cands = [p for p in root.glob('**/*.csv') if 'qqq' in p.name.lower()]
     if not cands:
-        raise FileNotFoundError('No CSV containing "qqq" found in /mnt/data.')
+        raise FileNotFoundError(f'No CSV containing "qqq" found in {root}.')
     return cands[0]
 
 if __name__ == '__main__':
     import argparse, sys
     ap = argparse.ArgumentParser(description='Enrich QQQ 5‑min bars with astro data')
-    ap.add_argument('--csv', type=Path, help='Path to raw QQQ CSV')
+    ap.add_argument('--csv', type=Path,
+                    help='Path to raw QQQ CSV (default: search $QQQ_DATA_DIR)')
     ap.add_argument('--out', type=Path, help='Output path (default: same dir, *_enriched.csv)')
     args = ap.parse_args()
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # QQQAstro
 QQQAstro
+
+## Environment variable
+
+When the `--csv` option is omitted, the script looks for a CSV file
+containing `qqq` in the directory specified by the `QQQ_DATA_DIR`
+environment variable. If the variable is unset, `./mnt/data` is used.


### PR DESCRIPTION
## Summary
- auto-detect CSV path using `$QQQ_DATA_DIR`
- improve CLI help text and usage notes
- document environment variable in README

## Testing
- `python -m py_compile QQQAstro.py`
- `python QQQAstro.py --help` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_684894a612d0832180fcb89f37d66fea