### PR TITLE
Fix README cleanup and path consistency

### DIFF
--- a/QQQAstro.py
+++ b/QQQAstro.py
@@ -13,7 +13,7 @@ If --csv is omitted it tries to auto‑detect a QQQ‑named CSV in $QQQ_DATA_DIR
 (default: ./mnt/data)
 
   python QQQAstro.py --csv /path/to/QQQ.csv --out enriched.csv
-If --csv is omitted it tries to auto‑detect a QQQ‑named CSV in /mnt/data
+If --csv is omitted it tries to auto‑detect a QQQ‑named CSV in ./mnt/data
 
 """
 

--- a/README.md
+++ b/README.md
@@ -13,16 +13,14 @@ python QQQAstro.py --csv path/to/QQQ.csv --out result.csv
 ```
 If `--csv` is omitted the script tries to locate the file automatically in the
 directory defined by the `QQQ_DATA_DIR` environment variable. If that variable
-is unset it falls back to `/mnt/data`.
+is unset it falls back to `./mnt/data`.
 
-QQQAstro
 
 ## Environment variable
 
 When the `--csv` option is omitted, the script looks for a CSV file
 containing `qqq` in the directory specified by the `QQQ_DATA_DIR`
 environment variable. If the variable is unset, `./mnt/data` is used.
-=======
 Install dependencies with:
 
 ```bash


### PR DESCRIPTION
## Summary
- clean merge artifact lines from README
- standardize default data path docs to `./mnt/data`
- update docstring path in QQQAstro.py

## Testing
- `python -m py_compile QQQAstro.py`

------
https://chatgpt.com/codex/tasks/task_b_684898c6576883218096cfb189c7ed89