### PR TITLE
Fix swe.calc_ut return handling

### DIFF
--- a/QQQAstro.py
+++ b/QQQAstro.py
@@ -119,7 +119,8 @@ def swe_sidereal_longitude(planet_name: str, dt_utc: datetime) -> float:
         dt_utc.day,
         dt_utc.hour + dt_utc.minute / 60 + dt_utc.second / 3600,
     )
-    lon, _lat, _dist = swe.calc_ut(jd, pid, swe.FLG_SWIEPH | swe.FLG_SIDEREAL)
+    pos, _retflag = swe.calc_ut(jd, pid, swe.FLG_SWIEPH | swe.FLG_SIDEREAL)
+    lon = pos[0]
     return lon % 360
 
 def _get_skyfield_longitude(planet_key: str, dt_utc: datetime) -> float:


### PR DESCRIPTION
## Summary
- fix swe.calc_ut call in `swe_sidereal_longitude`

## Testing
- `python -m py_compile QQQAstro.py`
- `python QQQAstro.py --help` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_6850872218f883218ca94a39aee84ca8